### PR TITLE
Fix error for tabgenie --help and minor refactoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     extras_require={
         "dev": [
             "wheel",
+            "black",
         ],
         "deploy": [
             "gunicorn",


### PR DESCRIPTION
Refactoring towards faster flask cli

flask CLI could be really slow if
each command imports all the libraries also
from the other commands.

Solution: each command should import only its dependencies

This commit tried to refactored in this direction. But it seems that we need create_app on most of the commands For these commands it did not speed up the CLI.


About fixing the command. I just added `hasattr` in the line `if ctx and hasattr(ctx.obj, "disable_pipelines"):`
which fixed this problem.  Now it works. See the screenshots.

![Screenshot 2023-01-25 at 11 34 18](https://user-images.githubusercontent.com/229266/214541266-33a1c20b-d4c7-4c87-b2bf-458273d9739d.png)
![Screenshot 2023-01-25 at 11 16 51](https://user-images.githubusercontent.com/229266/214541275-7760f556-ac40-4631-8c37-0fe0b20757e0.png)

