### PR TITLE
Persistant favourites

### DIFF
--- a/src/tabgenie/loaders/multiwoz22.py
+++ b/src/tabgenie/loaders/multiwoz22.py
@@ -296,8 +296,6 @@ class MultiWOZ22(HFTabularDataset):
         turns = entry["turns"]
         dialogue_acts = list(dai2tuples(just_user_acts(turns)))
         t.props["reference"] = list(generate_natural_user_prompt(dialogue_acts))
-        # __import__("ipdb").set_trace()
-
 
         col_names = ["turn_id", "speaker", "utterance", "frames", "dialogue_acts"]
         display_cols = ["turn_id", "speaker", "utterance"]

--- a/src/tabgenie/main.py
+++ b/src/tabgenie/main.py
@@ -8,7 +8,7 @@ import linecache
 
 import coloredlogs
 import pandas as pd
-from flask import Flask, render_template, jsonify, request, send_file
+from flask import Flask, render_template, jsonify, request, send_file, session
 
 from .loaders import DATASET_CLASSES
 from .processing.processing import get_pipeline_class_by_name
@@ -19,6 +19,7 @@ STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
 
 
 app = Flask("tabgenie", template_folder=TEMPLATES_DIR, static_folder=STATIC_DIR)
+app.config.update(SECRET_KEY=os.urandom(24))
 
 file_handler = logging.FileHandler("error.log")
 file_handler.setLevel(logging.ERROR)
@@ -48,7 +49,12 @@ def get_pipeline_output():
     pipeline_name = content["pipeline"]
     out = run_pipeline(pipeline_name, pipeline_args=content, force=bool(content["edited_cells"]))
 
-    return {"out": str(out)}
+    return {"out": str(out), "session": get_session()}
+
+def get_session():
+    """Retrieve session with default values"""
+    session["favourites"] = session.get("favourites", {})
+    return session
 
 
 @app.route("/table", methods=["GET", "POST"])
@@ -58,6 +64,8 @@ def render_table():
     table_idx = int(request.args.get("table_idx"))
     displayed_props = json.loads(request.args.get("displayed_props"))
     table_data = get_table_data(dataset_name, split, table_idx, displayed_props)
+    logging.info(f"{session=} favourites {table_data['session']=}")
+
     return table_data
 
 
@@ -248,6 +256,7 @@ def get_table_data(dataset_name, split, table_idx, displayed_props):
         "total_examples": dataset.get_example_count(split),
         "dataset_info": dataset_info,
         "generated_outputs": generated_outputs,
+        "session": get_session(),
     }
 
 
@@ -264,6 +273,34 @@ def load_prompts():
         prompts[prompt_name] = prompt
 
     return prompts
+
+
+@app.route("/favourite", methods=["GET", "POST"])
+def favourites(): 
+    content = request.json
+    dataset = content.get("dataset")
+    split = content.get("split")
+    table_idx = content.get("table_idx")
+    action = content.get("action", "get_all")
+    if action in ["remove", "insert"]:
+        assert dataset and split and isinstance(table_idx, int), (dataset, split, table_idx)
+        favourite_id = f"{dataset}-{split}-{table_idx}"
+    if action == "remove":
+        if session.get("favourites"):
+            favourite = session.pop(favourite_id, None)
+            logging.info(f"Removed {favourite}")
+    elif action == "insert":
+        favourites = session.get("favourites", {})
+        favourites[favourite_id] = {"dataset": dataset, "split": split, "table_idx": table_idx}
+        session["favourites"] = favourites
+    elif action == "remove_all":
+        favourites = {}
+    else: 
+        assert action == "get_all"
+    favourite_d = session.get("favourites", {})
+    assert isinstance(favourite_d, dict)  # on dicts are applied jsonify
+    logging.info(f"favourite {content=} {session=}")
+    return favourite_d
 
 
 @app.route("/", methods=["GET", "POST"])

--- a/src/tabgenie/templates/index.html
+++ b/src/tabgenie/templates/index.html
@@ -114,6 +114,10 @@
               </button>
               <input type="checkbox" class="btn-check" id="edit-btn" onclick="toggle_edit();" autocomplete="off">
               <label class="btn btn-sm btn-outline-secondary" for="edit-btn">✎ Edit mode</label>
+              <!-- <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal"
+                data-bs-target="#your-edits-modal">
+                📝 Your edits <div id="your-edits-count"></div>
+              </button> -->
               <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal"
                 data-bs-target="#favourites-modal">
                 ★ Favourites
@@ -253,6 +257,25 @@
     </div>
   </div>
 
+  <!-- <div class="modal fade" id="your-edits-modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="your-edits-modal-label">Your edits</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <ul class="list-group list-group-flush" id="your-edits-dataset-mode-box"></ul>
+          <ul class="list-group list-group-flush" id="your-edits-notes-mode-box"></ul>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" onclick="clear_edits();">Delete all</button>
+            <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div> -->
+
   <div class="modal fade" id="favourites-modal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -261,8 +284,6 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-
-
           <ul class="list-group list-group-flush" id="favourites-box"></ul>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" onclick="clear_favourites();">Delete all</button>
@@ -282,6 +303,8 @@
   window.default_dataset = "{{ default_dataset }}";
   window.pipelines = {{ pipelines | tojson | safe }};
   window.prompts = {{ prompts | tojson | safe }};
+  window.favourites = {{ session.get("favourites", {}) | tojson | safe }};
+  window.editedCells = {{ session.get("editedCells", {}) | tojson | safe }};
 </script>
 
 <script src="{{ host_prefix }}/static/js/custom.js"></script>


### PR DESCRIPTION
Previously:
- favourite did not survive loading next exable `table_idx` ie iterating over dataset
- favourite did not survive page reload

Now:
- clicking star (favourite) and iterating over dataset is persistent
- clicking star (favourite) and changing split/dataset is persistant
   - **does not work with in debugging mode because dataset, split is stored in app.config and the app is reloaded when selecting new dataset.** I spent 1.5h debugging this :-/. See #68 
-  survives browser refresh (F5)