### PR TITLE
demo on backend for exporting notes to xlsx

### DIFF
--- a/src/tabgenie/utils/excel.py
+++ b/src/tabgenie/utils/excel.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
 
     w = WebNLG(path=None)
     w.load('dev')
-    
+
     tables = [
         {
             'table': h.prepare_table(h.data['dev'][675]),


### PR DESCRIPTION
# Exporting notes for annotation works (for xlsx)

I tested this procedure:
1. create notes
2. select export notes
3. select xlsx 

Warning: Now the xlsx option creates a combined xlsx for annotation instead of previously zip of individual examples 

What works: "Tabgenie-notes"  are added as properties. See the screenshot.

What should be improved:
- The default export option for export is "a current example" which IMO does not make sense now.
- It may be nice to export multiple individual xlsx as previously and now the combined one - but I gave up on naming the options properly.
- Infering which table properties are exported for annotation: currently reference is hard coded. Do the selection based on selected properties for current example in the UI at the moment of export.
- The API of `write_annotation_to_excel` why not operate on Table object itself?


<img width="1224" alt="Screenshot 2023-02-22 at 0 49 32" src="https://user-images.githubusercontent.com/229266/220493549-104fda36-9ded-44b7-b391-906524f261f6.png">